### PR TITLE
Fix storage check for UserScript on Chromium

### DIFF
--- a/src/tools/storage.js
+++ b/src/tools/storage.js
@@ -98,7 +98,7 @@ class ExtensionStorage {
  */
 function getAvailableStorage() {
     return  typeof browser != "undefined" && new ExtensionStorage(browser) || // eslint-disable-line no-undef
-            typeof chrome != "undefined" && new ExtensionStorage(chrome) || // eslint-disable-line no-undef
+            typeof chrome != "undefined" && chrome.storage !== undefined && new ExtensionStorage(chrome) || // eslint-disable-line no-undef
             window.localStorage ||
             window.sessionStorage ||
             new ObjectStorage({});


### PR DESCRIPTION
## Description

The UserScript version is not working because of the check for storage is broken on Chromium browsers.

https://github.com/Kir-Antipov/GitHub-Defreshed/blob/5b7a08d6706938d41b154d8175037e8e7238dfa1/src/tools/storage.js#L99-L105

https://github.com/Kir-Antipov/GitHub-Defreshed/blob/5b7a08d6706938d41b154d8175037e8e7238dfa1/src/tools/storage.js#L78-L81

The problem is that `@getAvailableStorage` line 101 `new ExtensionStorage(chrome)` actually runs because `chrome` is a global on Chromium browsers but it lacks storage. So to skip it we also need to check if `storage` exists.

## Other information

- **Browser**: Vivaldi 3.7
- **Operating System**: Windows 10 x64
- **GitHub-Defreshed version**: 3.0.0
