### PR TITLE
Fix repository page and links

### DIFF
--- a/src/fixers/repository/about-fixer.tsx
+++ b/src/fixers/repository/about-fixer.tsx
@@ -17,7 +17,7 @@ export default class AboutFixer extends Fixer {
     }
 
     apply() {
-        const repositoryContent = document.querySelector("main .repository-content");
+        const repositoryContent = document.querySelector("main .repository-content > div");
         const cell = repositoryContent.querySelector(".BorderGrid-cell");
         const about = cell.querySelector(".f4");
         const website = cell

--- a/src/fixers/repository/columns-fixer.ts
+++ b/src/fixers/repository/columns-fixer.ts
@@ -13,11 +13,11 @@ export default class ColumnsFixer extends Fixer {
     }
 
     waitUntilFixerReady() {
-        return waitUntilElementsReady("main:nth-child(1) .repository-content");
+        return waitUntilElementsReady("main:nth-child(1) .repository-content > div");
     }
 
     apply() {
-        const repositoryContent = document.querySelector(".repository-content");
+        const repositoryContent = document.querySelector(".repository-content > div");
         const gutter = repositoryContent.querySelector(".Layout--sidebarPosition-end");
         const inner = gutter.firstElementChild;
 

--- a/src/fixers/repository/container-fixer.ts
+++ b/src/fixers/repository/container-fixer.ts
@@ -17,6 +17,6 @@ export default class ContainerFixer extends Fixer {
 
     apply() {
         const container = document.querySelector("main .container-xl");
-        container.className = "container-lg clearfix new-discussion-timeline px-3";
+        container.className = "container-lg clearfix px-3";
     }
 }

--- a/src/fixers/repository/edit-details-fixer.ts
+++ b/src/fixers/repository/edit-details-fixer.ts
@@ -21,7 +21,7 @@ export default class EditDetailsFixer extends Fixer {
     apply() {
         const details = document.querySelector("main .repository-content .BorderGrid-row:nth-child(1) details");
         if (details) {
-            document.querySelector("main .repository-content").prepend(details);
+            document.querySelector("main .repository-content > div").prepend(details);
         }
     }
 }

--- a/src/fixers/repository/help-fixer.ts
+++ b/src/fixers/repository/help-fixer.ts
@@ -12,6 +12,6 @@ export default class HelpFixer extends Fixer {
     }
 
     waitUntilFixerReady() {
-        return waitUntilEntriesReady("main:nth-child(1) div.repository-content > :first-child");
+        return waitUntilEntriesReady("main:nth-child(1) div.repository-content > div > :first-child");
     }
 }

--- a/src/fixers/repository/language-bar-fixer.tsx
+++ b/src/fixers/repository/language-bar-fixer.tsx
@@ -29,7 +29,7 @@ export default class LanguageBarFixer extends Fixer {
             ]
             .map(this.extractLanguageData);
 
-        const container = document.querySelector(".repository-content");
+        const container = document.querySelector(".repository-content > div");
         const shouldBeOpen = await settings.openLanguagesByDefault;
 
         container.prepend(<LanguageBar open={shouldBeOpen} langs={langs}/>);

--- a/src/fixers/repository/summary-fixer.tsx
+++ b/src/fixers/repository/summary-fixer.tsx
@@ -157,7 +157,7 @@ export default class SummaryFixer extends Fixer {
             link = data.querySelector("a").href;
         } else {
             count = defaultCount;
-            link = `/${getRepoURL(location)}/${additionalPath}${pluralize(text, count)}`;
+            link = `/${getRepoURL(location)}/${additionalPath}${pluralize(text, 2)}`;
         }
 
         return <SummaryElement icon={icon} href={link} text={text} count={count} />;

--- a/src/fixers/repository/summary-fixer.tsx
+++ b/src/fixers/repository/summary-fixer.tsx
@@ -22,7 +22,7 @@ export default class SummaryFixer extends Fixer {
     async apply(location: string, backupContainer: HTMLElement) {
         const langsBar = document.querySelector(".repository-content details summary div.repository-lang-stats-graph");
         document
-            .querySelector(".repository-content")
+            .querySelector(".repository-content > div")
             .prepend(
                 <SummaryContainer rounded={!langsBar}>
                     {this.createCommitsSummaryElement(backupContainer)}

--- a/src/fixers/repository/topics-fixer.tsx
+++ b/src/fixers/repository/topics-fixer.tsx
@@ -22,7 +22,7 @@ export default class TopicsFixer extends Fixer {
     apply() {
         const firstTopic = document.querySelector("main .repository-content .BorderGrid-cell .topic-tag");
         document
-            .querySelector("main .repository-content")
+            .querySelector("main .repository-content > div")
             .prepend(
                 <TopicsContainer>
                     {firstTopic.parentElement}


### PR DESCRIPTION
I finally got some free time and worked on some fixes. This fixes #47 and fixes #49, maybe it helps with #48 too.

#49 broke because before `.container-xl` was the parent of `.repository-content`, but now it's the inverse, so I just changed to inject the stuff inside `.container-xl` instead.

Here's the updated script for those who wish to update: [github-defreshed.user.js.txt](https://github.com/Kir-Antipov/GitHub-Defreshed/files/8347034/github-defreshed.user.js.txt)

Wish you all the best, and stay safe.